### PR TITLE
Update minimum TLS values

### DIFF
--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -168,6 +168,7 @@ resource web 'Microsoft.Web/sites@2022-03-01' = {
       alwaysOn: true
       linuxFxVersion: 'PYTHON|3.11'
       ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
     }
     httpsOnly: true
   }
@@ -356,6 +357,7 @@ resource redisCache 'Microsoft.Cache/redis@2023-04-01' = {
     enableNonSslPort:false
     redisVersion:'6'
     publicNetworkAccess:'Disabled'
+    minimumTlsVersion: '1.2'
   }
 }    
 


### PR DESCRIPTION
Fixes a couple of security warnings as the default TLS accepted values for Redis and App Services are below the recommended standard (1.2)